### PR TITLE
fix: exec command args should be split into arrays

### DIFF
--- a/internal/go.go
+++ b/internal/go.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 )
 
 var goCmds = map[string]func(*Settings, []string) *Executor{
@@ -67,9 +66,9 @@ type Executor struct {
 }
 
 func (e *Executor) Do() *exec.Cmd {
-	command := strings.Join(e.args[1:], " ")
+	args := append([]string{e.cmd}, e.args[1:]...)
 	//nolint
-	cmd := exec.Command("go", e.cmd, command)
+	cmd := exec.Command("go", args...)
 	cmd.Env = os.Environ()
 	cmd.Dir = e.settings.OutputDir
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
fix #24 

[exec.Command](https://golang.org/pkg/os/exec/#Command)
> Command combines and quotes Args into a command line string

Should not join args into one string.